### PR TITLE
fix MSC3266 probing against Synapse

### DIFF
--- a/lib/client-server-state.ts
+++ b/lib/client-server-state.ts
@@ -352,7 +352,7 @@ async function performFetch(serverName: string): Promise<void> {
     const probeBase = discoveredEndpoint || `https://${serverName}`;
     const probeRoomId = encodeURIComponent(`!probe:${serverName}`);
     const msc3266Url =
-      `${probeBase}/_matrix/client/v1/room_summary/${probeRoomId}`;
+      `${probeBase}/_matrix/client/v1/room_summary/${probeRoomId}?via=${encodeURIComponent(serverName)}`;
     const { response: msc3266Resp } = await fetchWithTimeout(msc3266Url, PROBE_TIMEOUT_MS);
     if (msc3266Resp) {
       if (


### PR DESCRIPTION
MSC3266 would previously show as unsupported for Synapse running with `msc3266_enabled` set, as probing the endpoint without `via` parameters would result in a 400 M_UNKNOWN.

This pull request adds the required via parameters, properly allowing to check against 404 M_NOT_FOUND.